### PR TITLE
[FEAT] add fetched timestamp to frontmatter

### DIFF
--- a/src/util.ts
+++ b/src/util.ts
@@ -360,6 +360,10 @@ export const buildMarkdown = async (
    */
   const frontmatter = []
   if (plugin.settings.frontmatter) {
+    const fetchedAt = formatTimestamp(new Date().toString(), {
+      locale: plugin.settings.dateLocale,
+      format: plugin.settings.dateFormat,
+    })
     frontmatter.push(
       ...[
         '---',
@@ -367,6 +371,7 @@ export const buildMarkdown = async (
         `handle: "@${user.username}"`,
         `source: "https://twitter.com/${user.username}/status/${tweet.data.id}"`,
         `date: "${date}"`,
+        `fetched: "${fetchedAt}"`,
         ...metrics,
       ]
     )


### PR DESCRIPTION
For https://github.com/kbravh/obsidian-tweet-to-markdown/issues/26, add a `fetched` line to the frontmatter to show when the tweet was fetched. Useful for bibliographies, for example.